### PR TITLE
arm64: dts: sun50i: allow U-Boot to fixup the MAC address on Pine64

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-common.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-common.dtsi
@@ -45,6 +45,7 @@
 / {
 
 	aliases {
+		ethernet0 = &emac;
 		serial0 = &uart0;
 	};
 


### PR DESCRIPTION
U-Boot will fixup the MAC address using the value of the "ethaddr"
environment variable if the first Ethernet interface can be found under
"ethernet0".  Define an alias for this.

Feel free to use this commit as a fixup for commit 02ac84a510 ("arm64: dts: sun50i: enable Ethernet on both Pine64 models")
